### PR TITLE
Update index.html

### DIFF
--- a/app/views/accessibility/index.html
+++ b/app/views/accessibility/index.html
@@ -34,7 +34,7 @@
 
 <p>We are <a href='/accessibility/standards'>legally required</a> to ensure all content available through a browser (websites, services, and apps) are accessible, regardless of whether they are for staff internal use, or external users.</p>
 
-<p>When we talk about accessibility we must not think of it as just people with disabilities, it also means supporting everyone with temporary, situational and permenant access needs who may be using assisitve technology.</p>
+<p>When we talk about accessibility we must not think of it as just for disabled people, it also means supporting everyone with temporary, situational and permanent access needs who may be using assisitve technology.</p>
 
 <p>In the UK, <a href="https://www.scope.org.uk/media/disability-facts-figures/" target="_blank">one in five people have a disability</a> and around <a href="https://adhdaware.org.uk/what-is-adhd/neurodiversity-and-other-conditions/" target="_blank">15% of people are thought to be neurodiverse</a> .</p>
 


### PR DESCRIPTION
fix a typo and in the UK, language used for disability is the social model of accessibility, so we should say 'disabled people' instead of 'people with disabilities' (for reference, here for example: https://www.gov.uk/government/publications/inclusive-communication/portraying-disability)