### PR TITLE
Improve focus state in links in style guide

### DIFF
--- a/app/views/content-design/style-guide/index.html
+++ b/app/views/content-design/style-guide/index.html
@@ -9,72 +9,72 @@
 {% block content %}
 
 <ul class="dfe-atoz govuk-!-margin-top-3">
-    
-    <li><a href="#a">A</a></li> 
-    
-    <li><a href="#b">B</a></li> 
-    
-    <li><a href="#c">C</a></li> 
-    
-    <li><a href="#d">D</a></li> 
-    
-    <li><a href="#e">E</a></li> 
-    
-    <li><a href="#f">F</a></li> 
-    
-    <li><a href="#g">G</a></li> 
-    
-    <li><a href="#h">H</a></li> 
-    
-    <li><a href="#i">I</a></li> 
-    
-    <li><a href="#j">J</a></li> 
-    
-    <li><a href="#k">K</a></li> 
-    
-    <li><a href="#l">L</a></li> 
-    
-    <li><a href="#m">M</a></li> 
-    
-    <li><a href="#n">N</a></li> 
-    
-    <li><a href="#o">O</a></li> 
-    
-    <li><a href="#p">P</a></li> 
-    
-    <li><a href="#q">Q</a></li> 
-    
-    <li><a href="#r">R</a></li> 
-    
-    <li><a href="#s">S</a></li> 
-    
-    <li><a href="#t">T</a></li> 
-    
-    <li><a href="#u">U</a></li> 
-    
-    <li><a href="#v">V</a></li> 
-    
-    <li><a href="#w">W</a></li> 
 
-     <li><a href="#x">X</a></li> 
+    <li><a class="govuk-link" href="#a">A</a></li>
 
-    <li><a href="#y">Y</a></li> 
+    <li><a class="govuk-link" href="#b">B</a></li>
 
-    <li><a href="#z">Z</a></li> 
-    
+    <li><a class="govuk-link" href="#c">C</a></li>
+
+    <li><a class="govuk-link" href="#d">D</a></li>
+
+    <li><a class="govuk-link" href="#e">E</a></li>
+
+    <li><a class="govuk-link" href="#f">F</a></li>
+
+    <li><a class="govuk-link" href="#g">G</a></li>
+
+    <li><a class="govuk-link" href="#h">H</a></li>
+
+    <li><a class="govuk-link" href="#i">I</a></li>
+
+    <li><a class="govuk-link" href="#j">J</a></li>
+
+    <li><a class="govuk-link" href="#k">K</a></li>
+
+    <li><a class="govuk-link" href="#l">L</a></li>
+
+    <li><a class="govuk-link" href="#m">M</a></li>
+
+    <li><a class="govuk-link" href="#n">N</a></li>
+
+    <li><a class="govuk-link" href="#o">O</a></li>
+
+    <li><a class="govuk-link" href="#p">P</a></li>
+
+    <li><a class="govuk-link" href="#q">Q</a></li>
+
+    <li><a class="govuk-link" href="#r">R</a></li>
+
+    <li><a class="govuk-link" href="#s">S</a></li>
+
+    <li><a class="govuk-link" href="#t">T</a></li>
+
+    <li><a class="govuk-link" href="#u">U</a></li>
+
+    <li><a class="govuk-link" href="#v">V</a></li>
+
+    <li><a class="govuk-link" href="#w">W</a></li>
+
+     <li><a class="govuk-link" href="#x">X</a></li>
+
+    <li><a class="govuk-link" href="#y">Y</a></li>
+
+    <li><a class="govuk-link" href="#z">Z</a></li>
+
 </ul>
 
 
 
 {% markdown %}
 
- The style guide includes words and language that differ from the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">Government Digital Service (GDS) style guide </a> that are used across multiple teams or areas in DfE. 
+ The style guide includes words and language that differ from the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">Government Digital Service (GDS) style guide </a> that are used across multiple teams or areas in DfE.
 
 It's a guide, not a set of rules. If your service uses niche language, or research shows your users say something else, use the words your users understand.  
 
-If a word you use isn't there, start a conversation in the <a href="https://ukgovernmentdfe.slack.com/archives/C6L4J5DK6"> DfE #contentdesign Slack channel</a>, or email design.ops@education.gov.uk.
+If a word you use isn't there, start a conversation in the <a class="govuk-link" href="https://ukgovernmentdfe.slack.com/archives/C6L4J5DK6"> DfE #contentdesign Slack channel</a>, or email <a class="govuk-link" href="mailto:design.ops@education.gov.uk">design.ops@education.gov.uk</a>.
 
-You also can contribute to the DfE style guide on <a href="https://github.com/DFE-Digital/design/issues/111">GitHub</a>.
+You also can contribute to the DfE style guide on <a class="govuk-link" href="https://github.com/DFE-Digital/design/issues/111">GitHub</a>.
 
 ## A
 
@@ -90,7 +90,7 @@ Use a forward slash to separate the two years within a single academic year, for
 
 ### Acronyms
 
-We follow the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#abbreviations-and-acronyms">GDS style guide for acronyms</a>, however when the users of a product or service are civil servants, they often recognise the acronym more than the full name.  
+We follow the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#abbreviations-and-acronyms">GDS style guide for acronyms</a>, however when the users of a product or service are civil servants, they often recognise the acronym more than the full name.
 
 When this is the case, we write the acronym out first and then follow that with the full name in brackets. 
 
@@ -139,7 +139,7 @@ The exceptions are:
 
 financial years - use an en rule to separate the 2 years within a single financial year, for example, 'in the financial year 2016-17' 
 
-academic years - see <a href="/content-design/style-guide#academic-year">academic year</a>
+academic years - see <a class="govuk-link" href="/content-design/style-guide#academic-year">academic year</a>
 
 ### DfE Sign-in 
 Lower case 'f', upper case S, and hyphen. 
@@ -171,7 +171,7 @@ Upper case.
 
 ### Hyphenation
 
-We follow the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#hyphenation">GDS style guide on hyphenation</a>. 
+We follow the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#hyphenation">GDS style guide on hyphenation</a>.
 
 
 ## I
@@ -207,7 +207,7 @@ Project owner
 ## K
 ### Key stages 
 
-The <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#key-stage">GDS style guide uses lower case for key stages </a>.  
+The <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#key-stage">GDS style guide uses lower case for key stages </a>.
 
 Where key stages are referenced in services that are used by people who may not be familiar with the key stage system, add the age range in brackets afterwards. 
 
@@ -216,7 +216,7 @@ For example, you will teach pupils in key stage 3 (ages 11 to 14).
 ## L
 ### Local council vs local authority 
 
-The GDS style guide uses <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#local-council">local council </a>. Follow this unless you are writing for civil servants. They usually refer to a local authority instead. Use the language of your users. 
+The GDS style guide uses <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#local-council">local council </a>. Follow this unless you are writing for civil servants. They usually refer to a local authority instead. Use the language of your users.
 
 ## M
 ### Multi-academy trust 
@@ -241,7 +241,7 @@ This course takes approximately one year to complete.
 
 This apprenticeship takes 2 years and 6 months to complete. 
 
-You can use <a href="https://accessiblenumbers.com/">guidance to design services for people who need help with numbers</a>.
+You can use <a class="govuk-link" href="https://accessiblenumbers.com/">guidance to design services for people who need help with numbers</a>.
 
 ## O
 
@@ -358,9 +358,8 @@ When a candidate has been 'recruited', refer to them as trainees rather than can
 
 Use 'training partner' to describe a SCITT or lead school that works with an accredited body.  
 
- 
+In Publish, the accredited body that ratifies the courses for the school will see 'Training partners' in the primary navigation. See this <a class="govuk-link" href="https://becoming-a-teacher.design-history.education.gov.uk/publish-teacher-training-courses/viewing-training-partners-and-their-courses-if-youre-an-accredited-body/">design history about viewing training partners and their courses</a> if you're an accredited body.
 
-In Publish, the accredited body that ratifies the courses for the school will see 'Training partners' in the primary navigation. See this <a href="https://becoming-a-teacher.design-history.education.gov.uk/publish-teacher-training-courses/viewing-training-partners-and-their-courses-if-youre-an-accredited-body/">design history about viewing training partners and their courses</a> if you're an accredited body.  
 
  
 


### PR DESCRIPTION
This improves the focus style on links in the style guide, making them more accessible through a yellow background colour and black border on the bottom, rather than the default browser faint blue outline.

The blue colour of the links is also changed slightly.

## Before

<img width="832" alt="Screenshot 2023-08-30 at 10 36 03" src="https://github.com/DFE-Digital/design/assets/30665/9104a2fb-17ff-46f0-95a0-95091537d37e">

## After

<img width="850" alt="Screenshot 2023-08-30 at 10 34 38" src="https://github.com/DFE-Digital/design/assets/30665/7268e062-4f88-41f3-9832-871ea9cfdc3a">
