### PR TITLE
Use govuk-markdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const axios = require('axios')
 var dateFilter = require('nunjucks-date-filter')
 var markdown = require('nunjucks-markdown')
 var marked = require('marked')
+const GovukHTMLRenderer = require('govuk-markdown')
 var Recaptcha = require('express-recaptcha').RecaptchaV3
 const bodyParser = require('body-parser')
 const lunr = require('lunr')
@@ -65,6 +66,9 @@ var nunjuckEnv = nunjucks.configure(
 )
 
 nunjuckEnv.addFilter('date', dateFilter)
+marked.setOptions({
+  renderer: new GovukHTMLRenderer()
+})
 markdown.register(nunjuckEnv, marked.parse)
 
 nunjuckEnv.addFilter('formatNumber', function (number) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express-recaptcha": "^5.1.0",
         "fs": "^0.0.1-security",
         "govuk-frontend": "^4.7.0",
+        "govuk-markdown": "^0.4.0",
         "gulp-nunjucks-render": "^2.2.3",
         "gulp-webp": "^4.0.1",
         "helmet": "^6.1.5",
@@ -11231,6 +11232,29 @@
       "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/govuk-markdown": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-markdown/-/govuk-markdown-0.4.0.tgz",
+      "integrity": "sha512-DSEZ02kRVeAbOvNBUubEfPZxMRIjLfc26gfOcarDX7GXz6Ij9lBddhBOBylJ0IQaNGTQANgj8GF6radrYN66nQ==",
+      "dependencies": {
+        "highlight.js": "^11.5.0",
+        "marked": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/govuk-markdown/node_modules/marked": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express-recaptcha": "^5.1.0",
     "fs": "^0.0.1-security",
     "govuk-frontend": "^4.7.0",
+    "govuk-markdown": "^0.4.0",
     "gulp-nunjucks-render": "^2.2.3",
     "gulp-webp": "^4.0.1",
     "helmet": "^6.1.5",


### PR DESCRIPTION
This adds the govuk-markdown plugin for the `marked` parser for Markdown.

This will mean that, where markdown is used, paragraphs will have the `govuk-body` class added, links will have the `gov-link`, and so on for headings, lists and tables.

The main visual difference this will have is on links, where the `gov-link` class changes the colour slightly, and adds a more accessible focus state.

Once this is added, links in the existing pages that use markdown can use the markdown syntax instead of HTML.