### PR TITLE
Convert accessibility page to markdown

### DIFF
--- a/app/views/accessibility/index.html
+++ b/app/views/accessibility/index.html
@@ -39,16 +39,13 @@
 
     <div class="govuk-inset-text">Accessibility assurance should not be left until carrying out an evaluation. Manual and automated accessibility testing, testing with users with access needs and design reviews should be done throughout the service delivery lifecycle.</div>
 
-<p><a href="/tools/inclusivity-calculator" >Estimate how many people using your website might be disabled</a>. This will help you consider the types of people who may be using your service and who you should be testing with.</p>
+{% markdown %}
+[Estimate how many people using your website might be disabled](/tools/inclusivity-calculator). This will help you consider the types of people who may be using your service and who you should be testing with.
 
+We are [legally required](/accessibility/standards) to ensure all content available through a browser (websites, services, and apps) are accessible, regardless of whether they are for staff internal use, or external users.
 
+When we talk about accessibility we must not think of it as just for disabled people, it also means supporting everyone with temporary, situational and permanent access needs who may be using assisitve technology.
 
-<p>We are <a href='/accessibility/standards'>legally required</a> to ensure all content available through a browser (websites, services, and apps) are accessible, regardless of whether they are for staff internal use, or external users.</p>
-
-<p>When we talk about accessibility we must not think of it as just for disabled people, it also means supporting everyone with temporary, situational and permanent access needs who may be using assisitve technology.</p>
-
-<p>In the UK, <a href="https://www.scope.org.uk/media/disability-facts-figures/" target="_blank">one in five people have a disability</a> and around <a href="https://adhdaware.org.uk/what-is-adhd/neurodiversity-and-other-conditions/" target="_blank">15% of people are thought to be neurodivergent</a> .</p>
-
-
-
+In the UK, [one in five people have a disability](https://www.scope.org.uk/media/disability-facts-figures/) and around [15% of people are thought to be neurodivergent](https://adhdaware.org.uk/what-is-adhd/neurodiversity-and-other-conditions/).
+{% endmarkdown %}
 {% endblock %}


### PR DESCRIPTION
This fixes the link focus states (as the link class will be added automatically).