### PR TITLE
Further education should be lower case

### DIFF
--- a/app/views/content-design/style-guide/index.html
+++ b/app/views/content-design/style-guide/index.html
@@ -154,9 +154,9 @@ Lower case 'f', upper case S, and hyphen.
 This term replaces 'newly qualified teacher'. Newly qualified teacher used to apply to a teacher's first year of teaching, whereas an early career teacher applies to a teacher in their first two years of teaching. Lower case. 
 
 ## F
-### Further Education 
+### Further education 
 
-Upper case. 
+Lower case. See [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#f)
 
 ## G
 


### PR DESCRIPTION
(According to the GOV.UK style guide)