### PR TITLE
Use lower case in titles (where style is lower case)

### DIFF
--- a/app/views/content-design/style-guide/index.html
+++ b/app/views/content-design/style-guide/index.html
@@ -78,7 +78,7 @@ You also can contribute to the DfE style guide on <a class="govuk-link" href="ht
 
 ## A
 
-### Academic year 
+### academic year 
 
 Use months rather than the academic year when communicating with the public. 
 
@@ -88,7 +88,7 @@ Instead of, teacher training lasts one academic year.
 
 Use a forward slash to separate the two years within a single academic year, for example,'in the academic year 2016/17' 
 
-### Acronyms
+### acronyms
 We follow the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#abbreviations-and-acronyms">GDS style guide for acronyms</a>, however when the users of a product or service are civil servants, they often recognise the acronym more than the full name.
 
 When this is the case, we write the acronym out first and then follow that with the full name in brackets. 
@@ -101,10 +101,10 @@ You do not need to explain the acronym in full on every page in a series if the 
 
 If the task in the task list was to "Contact the ESFA (Education and Skills Funding Agency) about a thing", you would not need to use the full name in the task on the next page. You could just use the acronym there.
 
-### Adult-led 
+### adult-led 
 Hyphenated when used to describe an adult leading something, for example, 'an adult-led activity'. Not hyphenated in other circumstances 'this activity is adult led'. 
 
-### Apprenticeship name 
+### apprenticeship name 
 Use capitals for the names of specific courses, apprenticeships and their levels. 
 
 For example, you could do the Finance Assistant Level 2 Intermediate Apprenticeship to become an accounting technician. 
@@ -115,27 +115,27 @@ For example, you could do a level 3 advanced apprenticeship in finance or accoun
 
 ## B
 
-### Baby
+### baby
 A child aged 0 to 12 months. If they are older than 12 months, use child. 
 
-### Buy or buying
+### buy or buying
 Not procure or procurement. 
 
 ## C
 
-### Capitalisation 
+### capitalisation 
 
 Write in sentence case whenever possible. This is easier to read. 
 
 Capitalise division and department names, and specific job titles like Regional Director. 
 
-### Child-led 
+### child-led 
 
 Hyphenated when used to describe a child leading something, for example, 'a child-led activity'. Not hyphenated in other circumstances, for example, 'this activity is child led'. 
 
 ## D
 
-### Dates
+### dates
 Use 'to' in date ranges, rather than a hyphen or dash, for example, 'January to September 2015'; '2012 to 2015'.  
 
 The exceptions are:  
@@ -150,11 +150,11 @@ Lower case 'f', upper case S, and hyphen.
 
 ## E
 
-### Early career teacher (ECT) 
+### early career teacher (ECT) 
 This term replaces 'newly qualified teacher'. Newly qualified teacher used to apply to a teacher's first year of teaching, whereas an early career teacher applies to a teacher in their first two years of teaching. Lower case. 
 
 ## F
-### Further education 
+### further education 
 
 Lower case. See [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#f)
 
@@ -172,7 +172,7 @@ Do not use the acronym GIT when communicating to users.
 
 Upper case.
 
-### Hyphenation
+### hyphenation
 
 We follow the <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#hyphenation">GDS style guide on hyphenation</a>.
 
@@ -189,7 +189,7 @@ Use IT support instead of IT service provider or IT support provider.
 
 ## J
 
-### Job titles 
+### job titles 
 
 We try to avoid generic job titles because they can change regularly. We don't use the job title as an identifier alongside a name, for example:  
 
@@ -208,7 +208,7 @@ Project owner
 
 
 ## K
-### Key stages 
+### key stages 
 
 The <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#key-stage">GDS style guide uses lower case for key stages </a>.
 
@@ -217,12 +217,12 @@ Where key stages are referenced in services that are used by people who may not 
 For example, you will teach pupils in key stage 3 (ages 11 to 14). 
 
 ## L
-### Local council vs local authority 
+### local council vs local authority 
 
 The GDS style guide uses <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#local-council">local council</a>. Follow this unless you are writing for civil servants. They usually refer to a local authority instead. Use the language of your users.
 
 ## M
-### Multi-academy trust 
+### multi-academy trust 
 
 Hyphenate multi-academy. You may see this abbreviated as MAT. Follow the acronym guidance for MAT. 
 
@@ -232,7 +232,7 @@ Hyphenate multi-academy. You may see this abbreviated as MAT. Follow the acronym
 
 Never abbreviate National Careers Service to NCS. NCS is an abbreviation of National Citizen Service. 
 
-### Numbers 
+### numbers 
 
 Create a consistent way of writing time periods of 12 months or more.  
 
@@ -248,24 +248,24 @@ You can use <a class="govuk-link" href="https://accessiblenumbers.com/">guidance
 
 ## O
 
-### Off-the-job training 
+### off-the-job training 
 
 Hyphenate. 
 
  
 
-### On-the-job training 
+### on-the-job training 
 
 Hyphenate. 
 
 ## P
-### Parents and carers 
+### parents and carers 
 
 Always use parents and carers for inclusivity. 
 
  
 
-### Pupil versus student 
+### pupil versus student 
 
 Use 'pupil' when referring to primary or secondary school age children, and then use 'student' when referring to people in a Further or Higher Education setting. 
 
@@ -273,13 +273,13 @@ Use 'pupil' when referring to primary or secondary school age children, and then
 
 ## R
 
-### Recruitment cycle 
+### recruitment cycle 
 
 Use 'recruitment cycle' not 'recruitment year' for content aimed at providers and civil servants. 
 
 ## S
 
-### Service name 
+### service name 
 
 Try and use the service name as part of a sentence rather than using it as a noun. For example, we would say: 
 
@@ -323,21 +323,21 @@ These are:
 
 - National Careers Service 
 
-### Single academy trust 
+### single academy trust 
 
 No hyphen. 
 
-### Special educational needs co-ordinator (SENCo) or special educational needs and disabilities co-ordinator (SENDCo)
+### special educational needs co-ordinator (SENCo) or special educational needs and disabilities co-ordinator (SENDCo)
 
 We follow <a class="govuk-link" href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#special-educational-needsspecial-educational-needs-and-disabilities-send">the GOV.UK style guide for SEN and SEND</a>  and apply it to SENCo (special educational needs co-ordinator) and SENDCo (special educational needs and disabilities co-ordinator).
 
-### Subject knowledge enhancement course (SKE) 
+### subject knowledge enhancement course (SKE) 
 
 Use lowercase. Users spell out the acronym so we should say 'an SKE' (users pronounce it an 'es-kay-ee') rather than 'a SKE'. 
 
 ## T
 
-### Teacher training adviser 
+### teacher training adviser 
 
 Use 'teacher training adviser', not 'Get Into Teaching advisers'.  
 
@@ -357,11 +357,11 @@ Previously sometimes known in DfE by the acronym TVS. This was from the previous
 
  
 
-### Trainee 
+### trainee 
 
 When a candidate has been 'recruited', refer to them as trainees rather than candidates. This is relevant to provider-facing content. DfE has a service called Register trainee teachers. 
 
-### Training partner 
+### training partner 
 
 Use 'training partner' to describe a SCITT or lead school that works with an accredited body.  
 
@@ -374,7 +374,7 @@ Avoid the term 'ratify' as providers do not always know what it means.
 
 ## U
 
-### Unsuccessful application 
+### unsuccessful application 
 
 Do not say 'you were unsuccessful'. Try to make an unsuccessful application less about the person. For example, 'Your application was unsuccessful on this occasion, but you can apply again'. 
 


### PR DESCRIPTION
This avoids confusion and follows the convention of the GDS style guide: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style