### PR TITLE
Content Design London

### DIFF
--- a/app/views/inside-design/professions/content-design.html
+++ b/app/views/inside-design/professions/content-design.html
@@ -78,7 +78,11 @@
             <p class="govuk-body">If you're interested in retraining to become a content designer, here are some steps you can take:</p>
 
             <h3 class="govuk-heading-m">Learn about content design</h3>
-            <p class="govuk-body">Before starting your training, it's important to have a good understanding of what content design is and what it entails. Research online, read books, attend events, and talk to professionals in the profession to get an idea of what content design involves.</p>
+            <p class="govuk-body">Before starting your training, it's important to have a good understanding of what content design is and what it entails.</p> 
+              
+            <p class="govuk-body">Research online, read books, attend events, and talk to professionals in the profession to get an idea of what content design involves.</p>
+
+            <p class="govuk-body"> <a class="govuk-link" href="https://contentdesign.london/" target="_blank">Content Design London</a> has some great books to read and courses to attend.</p>
 
             <h3 class="govuk-heading-m">Develop relevant skills</h3>
             <p class="govuk-body">Content design requires a combination of skills, including writing, editing, user research, UX/UI design, and project management. Consider taking courses or workshops that can help you develop these skills.</p>
@@ -101,7 +105,7 @@
 
             <h2 class="govuk-heading-l">Network</h2>
 
-            <p class="govuk-body">Attend events and conferences to meet other content designers and learn about the latest trends and best practices in the profession. Consider joining a professional association, such as the <a href="https://contentdesign.london/" target="_blank" rel="noopener noreferrer" class="govuk-link">Content Design London</a> community, to connect with other designers and access resources and training opportunities.</p>
+            <p class="govuk-body">Attend events and conferences to meet other content designers and learn about the latest trends and best practices in the profession. Consider joining a professional association, such as <a href="https://contentdesign.london/content-club" target="_blank" rel="noopener noreferrer" class="govuk-link">Content Club</a>, to connect with other designers and access resources and training opportunities.</p>
 
             <p class="govuk-body">Other training and networks include:</p>
 


### PR DESCRIPTION
Added link to Content Design London as a place to read books and attend sessions.

Replaced 'professional association' link to Content Club, so that there aren't two Content Design London links.