### PR TITLE
Adding 'Typography' instructions to the 'Install DfE Frontend' page. Improving the way that the 'DfE Frontend' pages are surfaced across the site generally.

### DIFF
--- a/app/public/css/app.css
+++ b/app/public/css/app.css
@@ -289,6 +289,27 @@
     box-shadow: none;
 }
 
+/* Action List with responsive 2 column grid layout*/
+   
+@media (min-width: 641px) {
+    .dfe-action-list-grid {
+        width: 100%;
+        grid-template-columns: 1fr;
+    }
+
+    .dfe-action-list-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
+    gap: 0 10px;
+}
+
+    .dfe-action-list-grid li {
+        display: grid;
+        width: calc(100% - 10px);
+    }
+}
+
 
 /* Chevron Icon */
 

--- a/app/views/design-system/dfe-frontend/install.html
+++ b/app/views/design-system/dfe-frontend/install.html
@@ -126,11 +126,23 @@
             </div>
           </div>
 
+          <h3 class="govuk-heading-m">Typography</h3>
+
+          <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">6. Install DfE typography</h2>
+            </div>
+            <div class="govuk-summary-card__content">
+              <p class="govuk-body">If your site is on education.gov, you must use the Inter typeface and <a href="/design-system/styles/typography" title="Install DfE typography" target="_blank">install DfE typography</a>.</p>
+              <p class="govuk-body">You can skip this step if your site is not on education.gov.</p>
+            </div>
+          </div>
+
           <h3 class="govuk-heading-m">Run your app</h3>
 
           <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-              <h2 class="govuk-summary-card__title">6. Run your app</h2>
+              <h2 class="govuk-summary-card__title">7. Run your app</h2>
               <ul class="govuk-summary-card__actions">
                 <li class="govuk-summary-card__action">
                   <button class="govuk-button copy-btn" data-copy-target="run-code">Copy code</button>

--- a/app/views/design-system/index.html
+++ b/app/views/design-system/index.html
@@ -42,23 +42,12 @@
                 </svg>
               </a>
             </li>
-            <li>
-              <a href="/design-system/dfe-frontend/contribute" class="govuk-link govuk-link--no-visited-state">
-                            Contribute styles, components or patterns
-                            <svg class="chevron dfe-icon dfe-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                  <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-                </svg>
-              </a>
-            </li>
           </ul>
-
         </div>
       </div>
 
-      <div class="govuk-grid-row">
+      <div class="govuk-grid-row govuk-!-margin-top-5">
         <div class="govuk-grid-column-full">
-
-          <h2 class="govuk-heading-l govuk-!-margin-top-5">DfE Frontend design system</h2>
 
           <div class="dfe-grid-container">
             <div class="dfe-card">
@@ -86,6 +75,38 @@
                   class="govuk-link govuk-link--no-visited-state dfe-card-link--header">Patterns</a>
                 </h2>
                 <p class="govuk-body">Patterns for common design problems and user interactions.</p>
+              </div>
+            </div>
+          </div>
+
+          <h2 class="govuk-heading-l govuk-!-margin-top-5">DfE Frontend</h2>
+
+          <div class="dfe-grid-container">
+            <div class="dfe-card">
+              <div class="dfe-card-container">
+                <h2 class="govuk-heading-m">
+                  <a href="/design-system/dfe-frontend"
+                  class="govuk-link govuk-link--no-visited-state dfe-card-link--header">About DfE Frontend</a>
+                </h2>
+                <p class="govuk-body">What DfE Frontend is and when to use it.</p>
+              </div>
+            </div>
+            <div class="dfe-card">
+              <div class="dfe-card-container">
+                <h2 class="govuk-heading-m">
+                  <a href="/design-system/dfe-frontend/install"
+                  class="govuk-link govuk-link--no-visited-state dfe-card-link--header">Install DfE Frontend</a>
+                </h2>
+                <p class="govuk-body">A step-by-step guide to install the DfE Frontend package.</p>
+              </div>
+            </div>
+            <div class="dfe-card">
+              <div class="dfe-card-container">
+                <h2 class="govuk-heading-m">
+                  <a href="/design-system/dfe-frontend/contribute"
+                  class="govuk-link govuk-link--no-visited-state dfe-card-link--header">Contribute</a>
+                </h2>
+                <p class="govuk-body">Work with us to make new components, fix bugs, and improve documentation.</p>
               </div>
             </div>
           </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -31,8 +31,8 @@ govuk-!-padding-bottom-0' %} {% block content %}
       <div class="govuk-grid-column-full">
         <h2 class="govuk-heading-l">Popular</h2>
       </div>
-      <div class="govuk-grid-column-one-half">
-        <ul class="govuk-list dfe-action-list">
+      <div class="govuk-grid-column-full">
+        <ul class="govuk-list dfe-action-list govuk-list dfe-action-list-grid">
           <li>
             <a
               href="/standards"
@@ -54,10 +54,10 @@ govuk-!-padding-bottom-0' %} {% block content %}
           </li>
           <li>
             <a
-              href="/design-system"
+              href="/professions/framework"
               class="govuk-link govuk-link--no-visited-state"
             >
-              DfE Frontend
+              Design skills and capability framework
               <svg
                 class="chevron dfe-icon dfe-icon__chevron-right"
                 xmlns="http://www.w3.org/2000/svg"
@@ -73,10 +73,29 @@ govuk-!-padding-bottom-0' %} {% block content %}
           </li>
           <li>
             <a
-              href="/professions/framework"
+              href="/design-system"
               class="govuk-link govuk-link--no-visited-state"
             >
-              Design skills and capability framework
+              Design system
+              <svg
+                class="chevron dfe-icon dfe-icon__chevron-right"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"
+                ></path>
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a
+              href="/design-system/dfe-frontend"
+              class="govuk-link govuk-link--no-visited-state"
+            >
+              DfE Frontend
               <svg
                 class="chevron dfe-icon dfe-icon__chevron-right"
                 xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Hello! 👋 First time making a pull request while working with other people. If you'd like to talk about anything, I'd be happy to discuss it via a call or DMs on Teams or Slack.

I initially started this piece of work by wanting to improve the 'Install DfE Frontend' page with some content around typography, but it bloomed outwards from there after I noticed some other things I wanted to address.

### Install DfE Frontend page:
- Added an extra 'Typography' heading and content box as the 6th item of the instructions
- Moved the previous 6th item to be 7th

While doing this, I realised that the 'DfE Frontend' page is very difficult to find from an organic user journey. Currently, the only way to the 'DfE Frontend' page is via the 'Contribute styles, components or patterns' link on the 'Design system' page - you then have to use the left-hand nav on that page to navigate to its parent. I've made the following changes with a view to improving access to the DfE Frontend pages, as well as clarifying the difference between it and the design system.

### Homepage:

- Changed the current 'DfE Frontend' link in the popular action links to actually link to the 'DfE Frontend' page.
- Added a fourth link to the 'Design System' page.
- To reduce the amount of vertical space that this larger list now takes up, I've added CSS to turn it into a responsive 2-column grid layout at desktop resolutions. At mobile resolutions, it falls back to the standard single-column full-width display.

### Design System page:

- Added a new H2 and card row for 'DfE Frontend' to properly surface that page and its children. They're currently really difficult to find via an organic journey.

- I removed the first H2 on this page completely. I initially renamed this to just 'DfE design system', but on reflection there wasn't any value gained by duplicated what's already in the preceeding H1, so I stuck with the H2 instead. I moved the custom margin class to the grid-row div instead, so that the spacing is preserved.