### PR TITLE
Replace Slack channel link with Teams channel link

### DIFF
--- a/app/views/content-design/style-guide.html
+++ b/app/views/content-design/style-guide.html
@@ -147,8 +147,8 @@
                     something else, use the words your users understand.
 
                     If a word you use isn't here, <a class="govuk-link"
-                        href="https://ukgovernmentdfe.slack.com/archives/C6L4J5DK6">start a conversation in the DfE
-                        #contentdesign Slack channel</a>, or email <a class="govuk-link"
+                        href="https://teams.microsoft.com/l/channel/19%3A6b768534d64045b89db1872550d34fa0%40thread.tacv2/1%20-%20Content%20Design?groupId=8912a6b5-cc25-446b-99cd-2ad2eb8cf90f&tenantId=fad277c9-c60a-4da1-b5f3-b3b8b34a82f9">start a conversation in the DfE
+                        content design Teams channel</a>, or email <a class="govuk-link"
                         href="mailto:design.ops@education.gov.uk">design.ops@education.gov.uk</a> and suggest it is
                     added.
 


### PR DESCRIPTION
This work is related to Issue #316.

It replaces the content and link referencing the defunct content design channel on DfE Slack. The page now links to the content design channel on Teams.

## As is

<img width="1122" height="853" alt="style-guide-slack-link" src="https://github.com/user-attachments/assets/1833ce9e-0fc4-4781-82c8-ac84768fcf03" />
