### PR TITLE
Removes "Image example here" text from guidance

### DIFF
--- a/app/views/design-system/patterns/ask-users-for-feedback.html
+++ b/app/views/design-system/patterns/ask-users-for-feedback.html
@@ -301,8 +301,6 @@
 
                     <p class="govuk-body">That's an increase of 256.85%.</p>
 
-                    <p class="govuk-body"><b>IMAGE EXAMPLE HERE</b></p>
-
                     <h2 class="govuk-heading-l">Get feedback on a specific page</h2>
 
                     <p class="govuk-body">There is a third variant you can use if you want to gather feedback on a specific page.</p>


### PR DESCRIPTION
This removes a line of bold text that says "Image example here" that was intended to show where to add an example of feedback approach from Early years child development training.

We will add an image in its place soon.